### PR TITLE
feat: simplify string types to use only startswith/endswith constraints

### DIFF
--- a/examples/string_constraints_example.py
+++ b/examples/string_constraints_example.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""
+Example demonstrating the new string constraint features in mocksmith.
+
+This shows how to use the enhanced VARCHAR, CHAR, and TEXT types with
+Pydantic constraint parameters like min_length, pattern, transformations, etc.
+"""
+
+from pydantic import BaseModel, ValidationError
+
+from mocksmith import Char, Text, Varchar, mockable
+
+print("=== String Types with Constraints Example ===\n")
+
+# Example 1: User Registration with Validation
+print("1. User Registration Model with String Constraints:")
+
+
+@mockable
+class UserRegistration(BaseModel):
+    """User registration with various string constraints."""
+
+    # Username: 3-20 chars with transformations
+    username: Varchar(20, min_length=3, to_lower=True, strip_whitespace=True)
+
+    # Email: auto-lowercase and trim whitespace, must be company email
+    email: Varchar(255, to_lower=True, strip_whitespace=True, endswith="@company.com")
+
+    # Display name: 2-50 chars, no extra constraints
+    display_name: Varchar(50, min_length=2)
+
+    # Country code: exactly 2 chars, uppercase
+    country_code: Char(2, to_upper=True)
+
+    # Bio: optional text with min/max length
+    bio: Text(min_length=10, max_length=500, strip_whitespace=True)
+
+    # Referral code: must start with 'REF-' prefix
+    referral_code: Varchar(12, startswith="REF-", to_upper=True)
+
+
+# Test validation
+print("\nValidation examples:")
+
+# Invalid username (too short)
+try:
+    user = UserRegistration(
+        username="ab",  # Too short
+        email="test@company.com",
+        display_name="Test User",
+        country_code="us",
+        bio="Short bio",
+        referral_code="ref-123456",
+    )
+except ValidationError as e:
+    print(f"✗ Username validation: {e.errors()[0]['msg']}")
+
+# Invalid email domain
+try:
+    user = UserRegistration(
+        username="user_name",
+        email="test@example.com",  # Must end with @company.com
+        display_name="Test User",
+        country_code="us",
+        bio="This is my bio",
+        referral_code="ref-abc1234",
+    )
+except ValidationError as e:
+    print(f"✗ Email validation: {e.errors()[0]['msg']}")
+
+# Invalid referral code (missing prefix)
+try:
+    user = UserRegistration(
+        username="user_name",
+        email="test@company.com",
+        display_name="Test User",
+        country_code="us",
+        bio="This is my bio",
+        referral_code="abc1234",  # Missing 'REF-' prefix
+    )
+except ValidationError as e:
+    print(f"✗ Referral validation: {e.errors()[0]['msg']}")
+
+# Valid registration with transformations
+user = UserRegistration(
+    username="  JOHN_DOE_123  ",  # Will be lowercased and trimmed
+    email="  John.Doe@COMPANY.COM  ",  # Will be lowercased and trimmed
+    display_name="John Doe",
+    country_code="us",  # Will be uppercased
+    bio="   I am a software developer interested in databases.   ",  # Will be trimmed
+    referral_code="ref-abc1234",  # Will be uppercased to REF-ABC1234
+)
+
+print("\n✓ Valid user created:")
+print(f"  Username: {user.username}")
+print(f"  Email: '{user.email}' (transformed)")
+print(f"  Country: '{user.country_code}' (uppercased)")
+print(f"  Bio: '{user.bio}' (trimmed)")
+print(f"  Referral: {user.referral_code} (uppercased)")
+
+# Example 2: Product Catalog
+print("\n\n2. Product Catalog with String Constraints:")
+
+
+@mockable
+class Product(BaseModel):
+    """Product with various string validations."""
+
+    # SKU must start with 'PRD-'
+    sku: Char(8, startswith="PRD-")
+
+    # Product name
+    name: Varchar(100, min_length=3, strip_whitespace=True)
+
+    # Short description
+    summary: Varchar(200, min_length=10)
+
+    # Full description must be a review format
+    description: Text(min_length=50, max_length=5000, startswith="Product Review: ")
+
+    # Category (normalized to lowercase)
+    category: Varchar(50, to_lower=True, strip_whitespace=True)
+
+    # Brand (normalized to uppercase)
+    brand: Varchar(50, to_upper=True, strip_whitespace=True)
+
+
+product = Product(
+    sku="PRD-1234",
+    name="  Premium Wireless Headphones  ",
+    summary="High-quality wireless headphones with noise cancellation",
+    description="Product Review: These premium wireless headphones offer exceptional "
+    "sound quality with active noise cancellation. "
+    + "Features include 30-hour battery life, comfortable over-ear design, "
+    "and Bluetooth 5.0 connectivity.",
+    category="  Audio Equipment  ",
+    brand="  audiophile  ",
+)
+
+print(f"Product: {product.name.strip()}")
+print(f"  SKU: {product.sku}")
+print(f"  Category: '{product.category}' (lowercased)")
+print(f"  Brand: '{product.brand}' (uppercased)")
+
+# Example 3: Mock Generation
+print("\n\n3. Mock Data Generation with Constraints:")
+
+# Generate mock users
+print("\nGenerating 3 mock users:")
+for i in range(3):
+    mock_user = UserRegistration.mock()
+    print(f"\nUser {i+1}:")
+    print(f"  Username: {mock_user.username}")
+    print(f"  Email: {mock_user.email}")
+    print(f"  Country: {mock_user.country_code}")
+    print(f"  Referral: {mock_user.referral_code}")
+
+    # Verify constraints are respected
+    assert len(mock_user.username) >= 3
+    assert len(mock_user.username) <= 20
+    assert mock_user.email == mock_user.email.lower()
+    assert len(mock_user.country_code) == 2
+    assert mock_user.country_code == mock_user.country_code.upper()
+
+# Example 4: Using startswith/endswith for easier mock generation
+print("\n\n4. Using startswith/endswith Constraints:")
+
+
+@mockable
+class OrderSystem(BaseModel):
+    """Example using startswith/endswith for structured data."""
+
+    # Order IDs must start with ORD-
+    order_id: Varchar(20, startswith="ORD-")
+
+    # Invoice numbers start with INV- and end with current year
+    invoice_number: Varchar(20, startswith="INV-", endswith="-2024")
+
+    # Support ticket with prefix
+    ticket_id: Char(10, startswith="TKT-", to_upper=True)
+
+    # Customer notes with standard prefix
+    customer_note: Text(max_length=1000, startswith="Customer feedback: ")
+
+
+# Create sample order
+order = OrderSystem(
+    order_id="ORD-12345",
+    invoice_number="INV-001-2024",
+    ticket_id="tkt-abc123",  # Will be uppercased
+    customer_note="Customer feedback: Great service and fast delivery!",
+)
+
+print(f"Order ID: {order.order_id}")
+print(f"Invoice: {order.invoice_number}")
+print(f"Ticket: {order.ticket_id}")
+print(f"Note: {order.customer_note[:50]}...")
+
+# Generate mock orders
+print("\nGenerating 3 mock orders:")
+for i in range(3):
+    mock_order = OrderSystem.mock()
+    print(f"\nMock Order {i+1}:")
+    print(f"  Order ID: {mock_order.order_id}")
+    print(f"  Invoice: {mock_order.invoice_number}")
+    print(f"  Ticket: {mock_order.ticket_id}")
+
+    # Verify constraints
+    assert mock_order.order_id.startswith("ORD-")
+    assert mock_order.invoice_number.startswith("INV-") and mock_order.invoice_number.endswith(
+        "-2024"
+    )
+    assert mock_order.ticket_id.startswith("TKT-")
+    assert mock_order.customer_note.startswith("Customer feedback: ")
+
+# Example 5: Using Pydantic-specific kwargs
+print("\n\n5. Advanced: Using Pydantic-specific Parameters:")
+
+
+class StrictValidation(BaseModel):
+    """Example using additional Pydantic parameters."""
+
+    # Strict mode - won't coerce types
+    numeric_code: Varchar(10, startswith="ID", strict=True)
+
+    # Using Pydantic's built-in string constraints via kwargs
+    # (These are passed through to constr)
+    custom_field: Varchar(50, min_length=5)
+
+
+# This would fail in strict mode (trying to pass int instead of str)
+try:
+    StrictValidation(numeric_code=12345, custom_field="test")
+except ValidationError as e:
+    print(f"✗ Strict mode error: {e.errors()[0]['msg']}")
+
+# Valid with string
+valid = StrictValidation(numeric_code="ID12345", custom_field="valid_value")
+print(f"✓ Strict validation passed: {valid.numeric_code}")
+
+print("\n\n=== Key Features Demonstrated ===")
+print("1. min_length/max_length - Control string length")
+print("2. startswith/endswith - Simple prefix/suffix constraints")
+print("3. to_lower/to_upper - Automatic case conversion")
+print("4. strip_whitespace - Remove leading/trailing spaces")
+print("5. Works with both Pydantic validation and mock generation")
+print("6. Supports additional Pydantic parameters via **kwargs")
+print("7. Transformations happen during deserialization (input processing)")
+print("8. Mock generation intelligently handles startswith/endswith")

--- a/src/mocksmith/annotations.py
+++ b/src/mocksmith/annotations.py
@@ -55,44 +55,133 @@ except ImportError:
 
 
 # String Types
-def Varchar(length: int) -> Any:
-    """Variable-length string with maximum length.
+def Varchar(
+    length: int,
+    *,
+    min_length: Optional[int] = None,
+    startswith: Optional[str] = None,
+    endswith: Optional[str] = None,
+    strip_whitespace: bool = False,
+    to_lower: bool = False,
+    to_upper: bool = False,
+    **pydantic_kwargs: Any,
+) -> Any:
+    """Variable-length string with maximum length and optional constraints.
+
+    Args:
+        length: Maximum length of the string
+        min_length: Minimum length of the string
+        startswith: String must start with this prefix
+        endswith: String must end with this suffix
+        strip_whitespace: Whether to strip whitespace
+        to_lower: Convert to lowercase
+        to_upper: Convert to uppercase
+        **pydantic_kwargs: Additional Pydantic-specific arguments
 
     Example:
         class User(BaseModel):
-            name: Varchar(50)
-            email: Varchar(100)
+            name: Varchar(50, min_length=2)
+            email: Varchar(100, to_lower=True, endswith='@example.com')
+            username: Varchar(30, min_length=3, to_lower=True)
+            order_id: Varchar(20, startswith='ORD-')
     """
-    db_type = _VARCHAR(length)
+    db_type = _VARCHAR(
+        length,
+        min_length=min_length,
+        startswith=startswith,
+        endswith=endswith,
+        strip_whitespace=strip_whitespace,
+        to_lower=to_lower,
+        to_upper=to_upper,
+        **pydantic_kwargs,
+    )
     if _PYDANTIC_AVAILABLE:
         # Include both DBTypeValidator for Pydantic and the raw db_type for dataclasses
         return Annotated[str, _get_validator(db_type), db_type]
     return Annotated[str, db_type]
 
 
-def Char(length: int) -> Any:
-    """Fixed-length string (padded with spaces).
+def Char(
+    length: int,
+    *,
+    startswith: Optional[str] = None,
+    endswith: Optional[str] = None,
+    strip_whitespace: bool = False,
+    to_lower: bool = False,
+    to_upper: bool = False,
+    **pydantic_kwargs: Any,
+) -> Any:
+    """Fixed-length string (padded with spaces) with optional constraints.
+
+    Args:
+        length: Fixed length of the string
+        startswith: String must start with this prefix
+        endswith: String must end with this suffix
+        strip_whitespace: Whether to strip whitespace on input
+        to_lower: Convert to lowercase
+        to_upper: Convert to uppercase
+        **pydantic_kwargs: Additional Pydantic-specific arguments
 
     Example:
         class Account(BaseModel):
             code: Char(10)
-            country: Char(2)
+            country: Char(2, to_upper=True)
+            product_code: Char(8, startswith='PRD-')
     """
-    db_type = _CHAR(length)
+    db_type = _CHAR(
+        length,
+        startswith=startswith,
+        endswith=endswith,
+        strip_whitespace=strip_whitespace,
+        to_lower=to_lower,
+        to_upper=to_upper,
+        **pydantic_kwargs,
+    )
     if _PYDANTIC_AVAILABLE:
         return Annotated[str, _get_validator(db_type), db_type]
     return Annotated[str, db_type]
 
 
-def Text(*, max_length: Optional[int] = None) -> Any:
-    """Variable-length text field.
+def Text(
+    *,
+    max_length: Optional[int] = None,
+    min_length: Optional[int] = None,
+    startswith: Optional[str] = None,
+    endswith: Optional[str] = None,
+    strip_whitespace: bool = False,
+    to_lower: bool = False,
+    to_upper: bool = False,
+    **pydantic_kwargs: Any,
+) -> Any:
+    """Variable-length text field with optional constraints.
+
+    Args:
+        max_length: Optional maximum length
+        min_length: Minimum length of the text
+        startswith: Text must start with this prefix
+        endswith: Text must end with this suffix
+        strip_whitespace: Whether to strip whitespace
+        to_lower: Convert to lowercase
+        to_upper: Convert to uppercase
+        **pydantic_kwargs: Additional Pydantic-specific arguments
 
     Example:
         class Article(BaseModel):
-            content: Text()
+            content: Text(min_length=100)
             summary: Text(max_length=500)
+            description: Text(strip_whitespace=True)
+            review: Text(min_length=50, startswith='Review: ')
     """
-    db_type = _TEXT(max_length=max_length)
+    db_type = _TEXT(
+        max_length=max_length,
+        min_length=min_length,
+        startswith=startswith,
+        endswith=endswith,
+        strip_whitespace=strip_whitespace,
+        to_lower=to_lower,
+        to_upper=to_upper,
+        **pydantic_kwargs,
+    )
     if _PYDANTIC_AVAILABLE:
         return Annotated[str, _get_validator(db_type), db_type]
     return Annotated[str, db_type]

--- a/src/mocksmith/types/string.py
+++ b/src/mocksmith/types/string.py
@@ -9,13 +9,67 @@ if PYDANTIC_AVAILABLE:
 
 
 class VARCHAR(DBType[str]):
-    """Variable-length character string."""
+    """Variable-length character string with optional constraints.
 
-    def __init__(self, length: int):
+    Args:
+        length: Maximum length of the string
+        min_length: Minimum length of the string (optional)
+        startswith: String must start with this prefix (optional)
+        endswith: String must end with this suffix (optional)
+        strip_whitespace: Whether to strip whitespace (default: False)
+        to_lower: Convert to lowercase (default: False)
+        to_upper: Convert to uppercase (default: False)
+        **pydantic_kwargs: Additional Pydantic-specific arguments (e.g., strict)
+
+    Examples:
+        # Basic usage
+        name: Varchar(50)
+
+        # With prefix/suffix constraints for structured data
+        order_id: Varchar(20, startswith='ORD-')
+        email: Varchar(100, endswith='@company.com', to_lower=True)
+        invoice: Varchar(30, startswith='INV-', endswith='-2024')
+
+        # With transformations
+        username: Varchar(50, min_length=3, to_lower=True, strip_whitespace=True)
+    """
+
+    def __init__(
+        self,
+        length: int,
+        *,  # Force keyword-only args
+        min_length: Optional[int] = None,
+        startswith: Optional[str] = None,
+        endswith: Optional[str] = None,
+        strip_whitespace: bool = False,
+        to_lower: bool = False,
+        to_upper: bool = False,
+        **pydantic_kwargs: Any,
+    ):
         super().__init__()
         if length <= 0:
             raise ValueError("VARCHAR length must be positive")
+        if min_length is not None:
+            if min_length < 0:
+                raise ValueError("min_length cannot be negative")
+            if min_length > length:
+                raise ValueError("min_length cannot exceed length")
+
+        if startswith and len(startswith) >= length:
+            raise ValueError(f"startswith '{startswith}' is too long for VARCHAR({length})")
+        if endswith and len(endswith) >= length:
+            raise ValueError(f"endswith '{endswith}' is too long for VARCHAR({length})")
+        if startswith and endswith and len(startswith) + len(endswith) > length:
+            raise ValueError(f"startswith + endswith is too long for VARCHAR({length})")
+
         self.length = length
+        self.min_length = min_length
+        self.startswith = startswith
+        self.endswith = endswith
+        self.strip_whitespace = strip_whitespace
+        self.to_lower = to_lower
+        self.to_upper = to_upper
+        self.pydantic_kwargs = pydantic_kwargs
 
     @property
     def sql_type(self) -> str:
@@ -28,7 +82,27 @@ class VARCHAR(DBType[str]):
     def get_pydantic_type(self) -> Optional[Any]:
         """Return Pydantic constr type if available."""
         if PYDANTIC_AVAILABLE:
-            return constr(max_length=self.length)
+            # Build pattern from startswith/endswith if present
+            pattern = None
+            if self.startswith or self.endswith:
+                import re
+
+                if self.startswith and self.endswith:
+                    pattern = f"^{re.escape(self.startswith)}.*{re.escape(self.endswith)}$"
+                elif self.startswith:
+                    pattern = f"^{re.escape(self.startswith)}.*"
+                elif self.endswith:
+                    pattern = f".*{re.escape(self.endswith)}$"
+
+            return constr(
+                max_length=self.length,
+                min_length=self.min_length,
+                pattern=pattern,
+                strip_whitespace=self.strip_whitespace,
+                to_lower=self.to_lower,
+                to_upper=self.to_upper,
+                **self.pydantic_kwargs,
+            )
         return None
 
     def _validate_custom(self, value: Any) -> None:
@@ -36,20 +110,116 @@ class VARCHAR(DBType[str]):
         if not isinstance(value, str):
             raise ValueError(f"Expected string, got {type(value).__name__}")
 
-        if len(value) > self.length:
-            raise ValueError(f"String length {len(value)} exceeds maximum {self.length}")
+        # Apply transformations first
+        processed = value
+        if self.strip_whitespace:
+            processed = processed.strip()
+        if self.to_lower:
+            processed = processed.lower()
+        elif self.to_upper:
+            processed = processed.upper()
+
+        # Then validate
+        if len(processed) > self.length:
+            raise ValueError(f"String length {len(processed)} exceeds maximum {self.length}")
+
+        if self.min_length is not None and len(processed) < self.min_length:
+            raise ValueError(
+                f"String length {len(processed)} is less than minimum {self.min_length}"
+            )
+
+        if self.startswith and not processed.startswith(self.startswith):
+            raise ValueError(f"String must start with '{self.startswith}'")
+
+        if self.endswith and not processed.endswith(self.endswith):
+            raise ValueError(f"String must end with '{self.endswith}'")
 
     def _serialize(self, value: str) -> str:
+        # Serialization just returns the value as-is
+        # (transformations already applied during deserialization)
         return value
 
     def _deserialize(self, value: Any) -> str:
-        return str(value)
+        # Convert to string first
+        result = str(value)
+        # Apply transformations during deserialization
+        if self.strip_whitespace:
+            result = result.strip()
+        if self.to_lower:
+            result = result.lower()
+        elif self.to_upper:
+            result = result.upper()
+        return result
 
     def __repr__(self) -> str:
-        return f"VARCHAR({self.length})"
+        parts = [f"VARCHAR({self.length}"]
+        if self.min_length is not None:
+            parts.append(f"min_length={self.min_length}")
+        if self.startswith:
+            parts.append(f"startswith={self.startswith!r}")
+        if self.endswith:
+            parts.append(f"endswith={self.endswith!r}")
+        if self.strip_whitespace:
+            parts.append("strip_whitespace=True")
+        if self.to_lower:
+            parts.append("to_lower=True")
+        if self.to_upper:
+            parts.append("to_upper=True")
+        if self.pydantic_kwargs:
+            parts.extend(f"{k}={v!r}" for k, v in self.pydantic_kwargs.items())
+
+        if len(parts) > 1:
+            return f"{parts[0]}, {', '.join(parts[1:])})"
+        return parts[0] + ")"
 
     def _generate_mock(self, fake: Any) -> str:
-        """Generate mock VARCHAR data."""
+        """Generate mock VARCHAR data respecting constraints."""
+        # Handle startswith/endswith constraints
+        if self.startswith or self.endswith:
+            prefix = self.startswith or ""
+            suffix = self.endswith or ""
+            prefix_suffix_len = len(prefix) + len(suffix)
+
+            if prefix_suffix_len >= self.length:
+                # No room for random content, just use prefix + suffix
+                text = (prefix + suffix)[: self.length]
+            else:
+                # Calculate how many random chars we need between prefix and suffix
+                min_middle = max(0, (self.min_length or 1) - prefix_suffix_len)
+                max_middle = self.length - prefix_suffix_len
+
+                # Generate only the middle part
+                middle_chars = fake.random_int(min=min_middle, max=max_middle)
+                middle = fake.pystr(min_chars=middle_chars, max_chars=middle_chars)
+
+                text = prefix + middle + suffix
+        else:
+            text = self._generate_default_text(fake)
+
+        # Apply transformations
+        if self.strip_whitespace:
+            text = text.strip()
+        if self.to_lower:
+            text = text.lower()
+        elif self.to_upper:
+            text = text.upper()
+
+        # Ensure min/max length
+        if self.min_length and len(text) < self.min_length:
+            # Pad with random chars if too short
+            padding_needed = self.min_length - len(text)
+            text += fake.pystr(min_chars=padding_needed, max_chars=padding_needed)
+
+        # Ensure max length
+        if len(text) > self.length:
+            text = text[: self.length]
+
+        return text
+
+    def _generate_default_text(self, fake: Any) -> str:
+        """Generate default text based on length."""
+        min_len = self.min_length or 1
+
         if self.length <= 10:
             # For short strings, use a single word
             text = fake.word()
@@ -63,18 +233,68 @@ class VARCHAR(DBType[str]):
             # For very long strings, use paragraph
             text = fake.text(max_nb_chars=self.length)
 
-        # Ensure the text fits within the length constraint
-        return text[: self.length]
+        # Ensure minimum length
+        while len(text) < min_len:
+            text += " " + fake.word()
+
+        return text
 
 
 class CHAR(DBType[str]):
-    """Fixed-length character string."""
+    """Fixed-length character string with optional constraints.
 
-    def __init__(self, length: int):
+    CHAR is always padded to the specified length with spaces.
+
+    Args:
+        length: Fixed length of the string
+        startswith: String must start with this prefix (optional)
+        endswith: String must end with this suffix (optional)
+        strip_whitespace: Whether to strip whitespace on input (default: False)
+        to_lower: Convert to lowercase (default: False)
+        to_upper: Convert to uppercase (default: False)
+        **pydantic_kwargs: Additional Pydantic-specific arguments
+
+    Examples:
+        # Basic usage
+        code: Char(10)
+
+        # Country code - always uppercase
+        country: Char(2, to_upper=True)
+
+        # Product code with prefix
+        product_code: Char(8, startswith='PRD-')
+        ticket_id: Char(10, startswith='TKT-', to_upper=True)
+    """
+
+    def __init__(
+        self,
+        length: int,
+        *,  # Force keyword-only args
+        startswith: Optional[str] = None,
+        endswith: Optional[str] = None,
+        strip_whitespace: bool = False,
+        to_lower: bool = False,
+        to_upper: bool = False,
+        **pydantic_kwargs: Any,
+    ):
         super().__init__()
         if length <= 0:
             raise ValueError("CHAR length must be positive")
+
+        if startswith and len(startswith) >= length:
+            raise ValueError(f"startswith '{startswith}' is too long for CHAR({length})")
+        if endswith and len(endswith) >= length:
+            raise ValueError(f"endswith '{endswith}' is too long for CHAR({length})")
+        if startswith and endswith and len(startswith) + len(endswith) > length:
+            raise ValueError(f"startswith + endswith is too long for CHAR({length})")
+
         self.length = length
+        self.startswith = startswith
+        self.endswith = endswith
+        self.strip_whitespace = strip_whitespace
+        self.to_lower = to_lower
+        self.to_upper = to_upper
+        self.pydantic_kwargs = pydantic_kwargs
 
     @property
     def sql_type(self) -> str:
@@ -87,8 +307,27 @@ class CHAR(DBType[str]):
     def get_pydantic_type(self) -> Optional[Any]:
         """Return Pydantic constr type if available."""
         if PYDANTIC_AVAILABLE:
+            # Build pattern from startswith/endswith if present
+            pattern = None
+            if self.startswith or self.endswith:
+                import re
+
+                if self.startswith and self.endswith:
+                    pattern = f"^{re.escape(self.startswith)}.*{re.escape(self.endswith)}$"
+                elif self.startswith:
+                    pattern = f"^{re.escape(self.startswith)}.*"
+                elif self.endswith:
+                    pattern = f".*{re.escape(self.endswith)}$"
+
             # CHAR allows up to length, but we pad on serialize
-            return constr(max_length=self.length)
+            return constr(
+                max_length=self.length,
+                pattern=pattern,
+                strip_whitespace=self.strip_whitespace,
+                to_lower=self.to_lower,
+                to_upper=self.to_upper,
+                **self.pydantic_kwargs,
+            )
         return None
 
     def _validate_custom(self, value: Any) -> None:
@@ -96,23 +335,97 @@ class CHAR(DBType[str]):
         if not isinstance(value, str):
             raise ValueError(f"Expected string, got {type(value).__name__}")
 
-        if len(value) > self.length:
-            raise ValueError(f"String length {len(value)} exceeds maximum {self.length}")
+        # Apply transformations first
+        processed = value
+        if self.strip_whitespace:
+            processed = processed.strip()
+        if self.to_lower:
+            processed = processed.lower()
+        elif self.to_upper:
+            processed = processed.upper()
+
+        if len(processed) > self.length:
+            raise ValueError(f"String length {len(processed)} exceeds maximum {self.length}")
+
+        if self.startswith and not processed.startswith(self.startswith):
+            raise ValueError(f"String must start with '{self.startswith}'")
+
+        if self.endswith and not processed.endswith(self.endswith):
+            raise ValueError(f"String must end with '{self.endswith}'")
 
     def _serialize(self, value: str) -> str:
         # Pad with spaces to match CHAR behavior
         return value.ljust(self.length)
 
     def _deserialize(self, value: Any) -> str:
-        # Strip trailing spaces to match typical CHAR retrieval
-        return str(value).rstrip()
+        # Convert to string and strip trailing spaces (typical CHAR retrieval)
+        result = str(value).rstrip()
+        # Apply transformations
+        if self.strip_whitespace:
+            result = result.strip()
+        if self.to_lower:
+            result = result.lower()
+        elif self.to_upper:
+            result = result.upper()
+        return result
 
     def __repr__(self) -> str:
-        return f"CHAR({self.length})"
+        parts = [f"CHAR({self.length}"]
+        if self.startswith:
+            parts.append(f"startswith={self.startswith!r}")
+        if self.endswith:
+            parts.append(f"endswith={self.endswith!r}")
+        if self.strip_whitespace:
+            parts.append("strip_whitespace=True")
+        if self.to_lower:
+            parts.append("to_lower=True")
+        if self.to_upper:
+            parts.append("to_upper=True")
+        if self.pydantic_kwargs:
+            parts.extend(f"{k}={v!r}" for k, v in self.pydantic_kwargs.items())
+
+        if len(parts) > 1:
+            return f"{parts[0]}, {', '.join(parts[1:])})"
+        return parts[0] + ")"
 
     def _generate_mock(self, fake: Any) -> str:
-        """Generate mock CHAR data."""
-        # CHAR is fixed-length, so we generate appropriate data
+        """Generate mock CHAR data respecting constraints."""
+        # Handle startswith/endswith constraints
+        if self.startswith or self.endswith:
+            prefix = self.startswith or ""
+            suffix = self.endswith or ""
+            prefix_suffix_len = len(prefix) + len(suffix)
+
+            if prefix_suffix_len >= self.length:
+                # No room for random content, just use prefix + suffix
+                text = (prefix + suffix)[: self.length]
+            else:
+                # For CHAR, we need exactly self.length characters
+                middle_len = self.length - prefix_suffix_len
+                middle = fake.pystr(min_chars=middle_len, max_chars=middle_len)
+                text = prefix + middle + suffix
+        else:
+            text = self._generate_default_char_text(fake)
+
+        # Apply transformations
+        if self.strip_whitespace:
+            text = text.strip()
+        if self.to_lower:
+            text = text.lower()
+        elif self.to_upper:
+            text = text.upper()
+
+        # Ensure exact length (CHAR is fixed-length)
+        if len(text) > self.length:
+            text = text[: self.length]
+        else:
+            # Pad with spaces if needed
+            text = text.ljust(self.length)
+
+        return text
+
+    def _generate_default_char_text(self, fake: Any) -> str:
+        """Generate default CHAR text based on length."""
         if self.length <= 2:
             # For very short CHAR, use country/state codes
             text = fake.country_code()
@@ -122,24 +435,80 @@ class CHAR(DBType[str]):
         else:
             # For longer CHAR, use appropriate length text
             text = fake.text(max_nb_chars=self.length)
-
-        # Ensure exact length (CHAR is fixed-length)
-        if len(text) > self.length:
-            return text[: self.length]
-        else:
-            # Pad with spaces if needed
-            return text.ljust(self.length)
+        return text
 
 
 class TEXT(DBType[str]):
-    """Variable-length text with no specific upper limit."""
+    """Variable-length text with no specific upper limit.
 
-    def __init__(self, max_length: Optional[int] = None):
+    TEXT is typically used for large text content like descriptions, articles, etc.
+
+    Args:
+        max_length: Optional maximum length (database-specific)
+        min_length: Minimum length of the text (optional)
+        startswith: Text must start with this prefix (optional)
+        endswith: Text must end with this suffix (optional)
+        strip_whitespace: Whether to strip whitespace (default: False)
+        to_lower: Convert to lowercase (default: False)
+        to_upper: Convert to uppercase (default: False)
+        **pydantic_kwargs: Additional Pydantic-specific arguments
+
+    Examples:
+        # Basic usage - unlimited length
+        description: Text()
+
+        # With max length constraint
+        bio: Text(max_length=5000)
+
+        # Ensure minimum content
+        article: Text(min_length=100, max_length=10000)
+
+        # With prefix for structured content
+        review: Text(min_length=50, startswith='Review: ')
+        feedback: Text(startswith='Customer feedback: ', max_length=1000)
+    """
+
+    def __init__(
+        self,
+        max_length: Optional[int] = None,
+        *,  # Force keyword-only args
+        min_length: Optional[int] = None,
+        startswith: Optional[str] = None,
+        endswith: Optional[str] = None,
+        strip_whitespace: bool = False,
+        to_lower: bool = False,
+        to_upper: bool = False,
+        **pydantic_kwargs: Any,
+    ):
         super().__init__()
+        if max_length is not None and max_length <= 0:
+            raise ValueError("max_length must be positive")
+        if min_length is not None:
+            if min_length < 0:
+                raise ValueError("min_length cannot be negative")
+            if max_length is not None and min_length > max_length:
+                raise ValueError("min_length cannot exceed max_length")
+
+        if startswith and max_length and len(startswith) >= max_length:
+            raise ValueError(f"startswith '{startswith}' is too long for max_length {max_length}")
+        if endswith and max_length and len(endswith) >= max_length:
+            raise ValueError(f"endswith '{endswith}' is too long for max_length {max_length}")
+        if startswith and endswith and max_length and len(startswith) + len(endswith) > max_length:
+            raise ValueError(f"startswith + endswith is too long for max_length {max_length}")
+
         self.max_length = max_length
+        self.min_length = min_length
+        self.startswith = startswith
+        self.endswith = endswith
+        self.strip_whitespace = strip_whitespace
+        self.to_lower = to_lower
+        self.to_upper = to_upper
+        self.pydantic_kwargs = pydantic_kwargs
 
     @property
     def sql_type(self) -> str:
+        # Most databases don't support CHECK constraints on TEXT
+        # but we return basic type
         return "TEXT"
 
     @property
@@ -148,8 +517,36 @@ class TEXT(DBType[str]):
 
     def get_pydantic_type(self) -> Optional[Any]:
         """Return Pydantic constr type if available."""
-        if PYDANTIC_AVAILABLE and self.max_length:
-            return constr(max_length=self.max_length)
+        if PYDANTIC_AVAILABLE:
+            # Build pattern from startswith/endswith if present
+            pattern = None
+            if self.startswith or self.endswith:
+                import re
+
+                if self.startswith and self.endswith:
+                    pattern = f"^{re.escape(self.startswith)}.*{re.escape(self.endswith)}$"
+                elif self.startswith:
+                    pattern = f"^{re.escape(self.startswith)}.*"
+                elif self.endswith:
+                    pattern = f".*{re.escape(self.endswith)}$"
+
+            # Only apply constraints if we have them
+            kwargs = {
+                "strip_whitespace": self.strip_whitespace,
+                "to_lower": self.to_lower,
+                "to_upper": self.to_upper,
+                **self.pydantic_kwargs,
+            }
+            if self.max_length is not None:
+                kwargs["max_length"] = self.max_length
+            if self.min_length is not None:
+                kwargs["min_length"] = self.min_length
+            if pattern is not None:
+                kwargs["pattern"] = pattern
+
+            # Only create constr if we have constraints
+            if any(k in kwargs for k in ["max_length", "min_length", "pattern"]) or kwargs:
+                return constr(**kwargs)
         return None
 
     def _validate_custom(self, value: Any) -> None:
@@ -157,32 +554,147 @@ class TEXT(DBType[str]):
         if not isinstance(value, str):
             raise ValueError(f"Expected string, got {type(value).__name__}")
 
-        if self.max_length and len(value) > self.max_length:
-            raise ValueError(f"Text length {len(value)} exceeds maximum {self.max_length}")
+        # Apply transformations first
+        processed = value
+        if self.strip_whitespace:
+            processed = processed.strip()
+        if self.to_lower:
+            processed = processed.lower()
+        elif self.to_upper:
+            processed = processed.upper()
+
+        if self.max_length and len(processed) > self.max_length:
+            raise ValueError(f"Text length {len(processed)} exceeds maximum {self.max_length}")
+
+        if self.min_length is not None and len(processed) < self.min_length:
+            raise ValueError(f"Text length {len(processed)} is less than minimum {self.min_length}")
+
+        if self.startswith and not processed.startswith(self.startswith):
+            raise ValueError(f"Text must start with '{self.startswith}'")
+
+        if self.endswith and not processed.endswith(self.endswith):
+            raise ValueError(f"Text must end with '{self.endswith}'")
 
     def _serialize(self, value: str) -> str:
+        # Serialization just returns the value as-is
+        # (transformations already applied during deserialization)
         return value
 
     def _deserialize(self, value: Any) -> str:
-        return str(value)
+        # Convert to string first
+        result = str(value)
+        # Apply transformations during deserialization
+        if self.strip_whitespace:
+            result = result.strip()
+        if self.to_lower:
+            result = result.lower()
+        elif self.to_upper:
+            result = result.upper()
+        return result
 
     def __repr__(self) -> str:
-        if self.max_length:
-            return f"TEXT(max_length={self.max_length})"
-        return "TEXT()"
+        parts = ["TEXT("]
+        params = []
+        if self.max_length is not None:
+            params.append(f"max_length={self.max_length}")
+        if self.min_length is not None:
+            params.append(f"min_length={self.min_length}")
+        if self.startswith:
+            params.append(f"startswith={self.startswith!r}")
+        if self.endswith:
+            params.append(f"endswith={self.endswith!r}")
+        if self.strip_whitespace:
+            params.append("strip_whitespace=True")
+        if self.to_lower:
+            params.append("to_lower=True")
+        if self.to_upper:
+            params.append("to_upper=True")
+        if self.pydantic_kwargs:
+            params.extend(f"{k}={v!r}" for k, v in self.pydantic_kwargs.items())
+
+        return parts[0] + ", ".join(params) + ")"
 
     def _generate_mock(self, fake: Any) -> str:
-        """Generate mock TEXT data."""
-        if self.max_length:
-            if self.max_length <= 200:
+        """Generate mock TEXT data respecting constraints."""
+        # Handle startswith/endswith constraints
+        if self.startswith or self.endswith:
+            prefix = self.startswith or ""
+            suffix = self.endswith or ""
+            prefix_suffix_len = len(prefix) + len(suffix)
+
+            # Determine target length
+            if self.max_length and self.min_length:
+                target_length = fake.random_int(min=self.min_length, max=self.max_length)
+            elif self.max_length:
+                target_length = fake.random_int(
+                    min=max(prefix_suffix_len + 10, 50), max=self.max_length
+                )
+            elif self.min_length:
+                target_length = fake.random_int(min=self.min_length, max=self.min_length + 500)
+            else:
+                target_length = fake.random_int(min=200, max=1000)
+
+            # Calculate middle content length
+            middle_length = target_length - prefix_suffix_len
+
+            if middle_length <= 0:
+                text = (prefix + suffix)[:target_length]
+            elif middle_length <= 50:
+                # Short text - use pystr for random chars
+                middle = fake.pystr(min_chars=middle_length, max_chars=middle_length)
+                text = prefix + middle + suffix
+            else:
+                # Longer text - use meaningful content
+                middle = fake.text(max_nb_chars=middle_length * 2)  # Generate extra to trim
+                middle = middle.strip()
+                if len(middle) > middle_length:
+                    middle = middle[:middle_length].rstrip()
+                elif len(middle) < middle_length:
+                    # Pad with random chars to reach exact length
+                    padding_needed = middle_length - len(middle)
+                    middle = (
+                        middle
+                        + " "
+                        + fake.pystr(min_chars=padding_needed - 1, max_chars=padding_needed - 1)
+                    )
+                text = prefix + middle + suffix
+        else:
+            # Determine target length
+            if self.max_length and self.min_length:
+                # Generate between min and max
+                target_length = fake.random_int(min=self.min_length, max=self.max_length)
+            elif self.max_length:
+                # Generate up to max
+                target_length = fake.random_int(min=10, max=self.max_length)
+            elif self.min_length:
+                # Generate at least min
+                target_length = fake.random_int(min=self.min_length, max=self.min_length + 500)
+            else:
+                # Default reasonable length
+                target_length = 500
+
+            # Generate text
+            if target_length <= 200:
                 # For smaller text, use paragraph
                 text = fake.paragraph(nb_sentences=3)
             else:
                 # For larger text, use multiple paragraphs
-                text = fake.text(max_nb_chars=min(self.max_length, 1000))
+                text = fake.text(max_nb_chars=target_length)
 
-            # Ensure it fits within max_length
-            return text[: self.max_length]
-        else:
-            # No limit, generate a reasonable amount of text
-            return fake.text(max_nb_chars=500)
+            # Ensure min length by adding more content if needed
+            while self.min_length and len(text) < self.min_length:
+                text += " " + fake.paragraph()
+
+        # Apply transformations
+        if self.strip_whitespace:
+            text = text.strip()
+        if self.to_lower:
+            text = text.lower()
+        elif self.to_upper:
+            text = text.upper()
+
+        # Ensure max length
+        if self.max_length and len(text) > self.max_length:
+            text = text[: self.max_length]
+
+        return text


### PR DESCRIPTION
- Remove pattern parameter completely from VARCHAR, CHAR, and TEXT types
  - Simplify API by supporting only startswith/endswith for string validation
  - Improve mock data generation by calculating exact middle content length
  - Update annotation functions and examples to reflect the changes
  - Update tests to remove pattern-related tests and add length validation tests

  BREAKING CHANGE: The pattern parameter has been removed from all string types.
  Users should use startswith/endswith for prefix/suffix validation. For complex
  validation requiring regex patterns, users should implement custom validators.
