### PR TITLE
feat!: migrate temporal types to V3 pattern

### DIFF
--- a/src/mocksmith/annotations.py
+++ b/src/mocksmith/annotations.py
@@ -4,7 +4,6 @@ This module provides clean, easy-to-use type annotations for both
 Pydantic models and Python dataclasses.
 """
 
-from datetime import date, datetime, time
 from decimal import Decimal
 from typing import Annotated, Any, Optional, Union
 
@@ -31,9 +30,10 @@ from mocksmith.types.numeric import TinyInt as TinyIntImpl
 from mocksmith.types.string import CHAR as _CHAR
 from mocksmith.types.string import TEXT as _TEXT
 from mocksmith.types.string import VARCHAR as _VARCHAR
-from mocksmith.types.temporal import DATE as _DATE
-from mocksmith.types.temporal import TIME as _TIME
-from mocksmith.types.temporal import TIMESTAMP as _TIMESTAMP
+from mocksmith.types.temporal import Date as DateImpl
+from mocksmith.types.temporal import DateTime as DateTimeImpl
+from mocksmith.types.temporal import Time as TimeImpl
+from mocksmith.types.temporal import Timestamp as TimestampImpl
 
 # For Pydantic models - check if Pydantic is available
 try:
@@ -627,10 +627,8 @@ def Date() -> Any:
             birth_date: Date()
             hire_date: Date()
     """
-    db_type = _DATE()
-    if _PYDANTIC_AVAILABLE:
-        return Annotated[date, _get_validator(db_type), db_type]
-    return Annotated[date, db_type]
+    # Use V3 Date type directly
+    return DateImpl()
 
 
 def Time(*, precision: int = 6) -> Any:
@@ -641,10 +639,8 @@ def Time(*, precision: int = 6) -> Any:
             start_time: Time()
             end_time: Time(precision=0)  # No fractional seconds
     """
-    db_type = _TIME(precision=precision)
-    if _PYDANTIC_AVAILABLE:
-        return Annotated[time, _get_validator(db_type), db_type]
-    return Annotated[time, db_type]
+    # Use V3 Time type directly
+    return TimeImpl(precision=precision)
 
 
 def Timestamp(*, precision: int = 6, with_timezone: bool = True) -> Any:
@@ -656,10 +652,8 @@ def Timestamp(*, precision: int = 6, with_timezone: bool = True) -> Any:
             updated_at: Timestamp(with_timezone=False)
             processed_at: Timestamp(precision=3)  # Milliseconds
     """
-    db_type = _TIMESTAMP(precision=precision, with_timezone=with_timezone)
-    if _PYDANTIC_AVAILABLE:
-        return Annotated[datetime, _get_validator(db_type), db_type]
-    return Annotated[datetime, db_type]
+    # Use V3 Timestamp type directly
+    return TimestampImpl(precision=precision, with_timezone=with_timezone)
 
 
 def DateTime(*, precision: int = 6) -> Any:
@@ -670,7 +664,8 @@ def DateTime(*, precision: int = 6) -> Any:
             timestamp: DateTime()
             processed: DateTime(precision=0)
     """
-    return Timestamp(precision=precision, with_timezone=False)
+    # Use V3 DateTime type directly
+    return DateTimeImpl(precision=precision)
 
 
 # Boolean Type

--- a/src/mocksmith/types/temporal.py
+++ b/src/mocksmith/types/temporal.py
@@ -1,182 +1,671 @@
-"""Temporal database types."""
+"""Temporal types with V3 pattern - extends Python datetime types directly."""
 
-from datetime import date, datetime, time
-from typing import Any, Union
+from datetime import date, datetime, time, timezone
+from typing import Any, ClassVar
 
-from mocksmith.types.base import DBType
+try:
+    from pydantic import GetCoreSchemaHandler  # type: ignore
+    from pydantic_core import PydanticCustomError, core_schema  # type: ignore
+
+    PYDANTIC_AVAILABLE = True
+except ImportError:
+    PYDANTIC_AVAILABLE = False
+    GetCoreSchemaHandler = Any
+    core_schema = None
+    PydanticCustomError = ValueError
 
 
-class DATE(DBType[date]):
-    """Date type (year, month, day)."""
+class DATE(date):
+    """Date type that validates at instantiation."""
+
+    SQL_TYPE: ClassVar[str] = "DATE"
+
+    def __new__(cls, year: Any, month: Any = None, day: Any = None):  # type: ignore
+        """Create new date with validation.
+
+        Can be called with:
+        - DATE(2024, 3, 15) - separate year, month, day
+        - DATE("2024-03-15") - ISO format string
+        - DATE(date_obj) - existing date object
+        - DATE(datetime_obj) - datetime (extracts date part)
+        """
+        # Handle single argument cases
+        if month is None and day is None:
+            value = year
+
+            if value is None:  # type: ignore[comparison-overlap]
+                raise ValueError("DATE cannot be None")
+
+            # Handle existing date/datetime
+            if isinstance(value, datetime):
+                return super().__new__(cls, value.year, value.month, value.day)
+            elif isinstance(value, date):
+                return super().__new__(cls, value.year, value.month, value.day)
+            # Handle string
+            elif isinstance(value, str):  # type: ignore[unreachable]
+                try:
+                    parsed = date.fromisoformat(value)
+                    return super().__new__(cls, parsed.year, parsed.month, parsed.day)
+                except ValueError as e:
+                    raise ValueError(f"Invalid date string: {value}") from e
+            else:
+                raise ValueError(f"Cannot convert {type(value).__name__} to date")
+
+        # Handle three argument case (year, month, day)
+        try:
+            return super().__new__(cls, int(year), int(month), int(day))
+        except (ValueError, TypeError) as e:
+            raise ValueError(
+                f"Invalid date components: year={year}, month={month}, day={day}"
+            ) from e
 
     @property
     def sql_type(self) -> str:
-        return "DATE"
+        """Return SQL type for compatibility."""
+        return self.SQL_TYPE
 
-    @property
-    def python_type(self) -> type[date]:
-        return date
+    def serialize(self) -> str:
+        """Serialize to ISO format string for SQL."""
+        return self.isoformat()
 
-    def _validate_custom(self, value: Any) -> None:
-        """Validate date value."""
-        if not isinstance(value, (date, datetime, str)):
-            raise ValueError(f"Expected date value, got {type(value).__name__}")
+    @classmethod
+    def validate(cls, value: Any) -> date:
+        """Validate a value without creating an instance (compatibility method)."""
+        instance = cls(value)
+        return date(instance.year, instance.month, instance.day)
 
-        if isinstance(value, str):
+    @classmethod
+    def __get_pydantic_core_schema__(cls, source_type: Any, handler: GetCoreSchemaHandler) -> Any:
+        """Define Pydantic validation schema."""
+        if not PYDANTIC_AVAILABLE:
+            return None
+
+        def validate_date(value: Any) -> date:
+            """Validate and convert to date."""
             try:
-                date.fromisoformat(value)
+                instance = cls(value)
+                return date(instance.year, instance.month, instance.day)
             except ValueError as e:
-                raise ValueError(f"Invalid date string: {e}") from e
+                raise PydanticCustomError("date_type", str(e)) from e
 
-    def _serialize(self, value: Union[date, datetime, str]) -> str:
-        if isinstance(value, datetime):
-            return value.date().isoformat()
-        elif isinstance(value, date):
-            return value.isoformat()
-        else:  # str
-            # Validate and normalize
-            return date.fromisoformat(value).isoformat()
+        return core_schema.no_info_after_validator_function(  # type: ignore
+            validate_date,
+            core_schema.union_schema(  # type: ignore
+                [
+                    core_schema.date_schema(),  # type: ignore
+                    core_schema.datetime_schema(),  # type: ignore
+                    core_schema.str_schema(),  # type: ignore
+                ]
+            ),
+        )
 
-    def _deserialize(self, value: Any) -> date:
-        if isinstance(value, date) and not isinstance(value, datetime):
-            return value
-        elif isinstance(value, datetime):
-            return value.date()
-        else:
-            return date.fromisoformat(str(value))
+    @classmethod
+    def mock(cls) -> date:
+        """Generate mock date value."""
+        try:
+            from faker import Faker  # type: ignore
+
+            fake = Faker()
+            return fake.date_object()
+        except ImportError:
+            raise ImportError("faker library is required for mock generation") from None
 
 
-class TIME(DBType[time]):
-    """Time type (hour, minute, second, microsecond)."""
+class TIME(time):
+    """Time type that validates at instantiation."""
 
-    def __init__(self, precision: int = 6):
-        super().__init__()
-        if precision < 0 or precision > 6:
-            raise ValueError("Time precision must be between 0 and 6")
-        self.precision = precision
+    SQL_TYPE: ClassVar[str] = "TIME"
+    _precision: ClassVar[int] = 6
+
+    def __new__(  # type: ignore
+        cls,
+        hour: Any = 0,
+        minute: Any = 0,
+        second: Any = 0,
+        microsecond: Any = 0,
+        *,
+        tzinfo: Any = None,
+        fold: int = 0,
+    ):
+        """Create new time with validation.
+
+        Can be called with:
+        - TIME(14, 30, 45) - hour, minute, second
+        - TIME("14:30:45") - ISO format string
+        - TIME(time_obj) - existing time object
+        - TIME(datetime_obj) - datetime (extracts time part)
+        """
+        # Handle single argument case
+        if (
+            isinstance(hour, (str, time, datetime))
+            and minute == 0
+            and second == 0
+            and microsecond == 0
+        ):
+            value = hour
+
+            if value is None:  # type: ignore[comparison-overlap]
+                raise ValueError("TIME cannot be None")
+
+            # Handle existing time/datetime
+            if isinstance(value, datetime):
+                value = value.time()
+
+            if isinstance(value, time):
+                hour = value.hour
+                minute = value.minute
+                second = value.second
+                microsecond = value.microsecond
+                tzinfo = value.tzinfo
+                fold = value.fold
+            # Handle string
+            elif isinstance(value, str):  # type: ignore[unreachable]
+                try:
+                    parsed = time.fromisoformat(value)
+                    hour = parsed.hour
+                    minute = parsed.minute
+                    second = parsed.second
+                    microsecond = parsed.microsecond
+                    tzinfo = parsed.tzinfo
+                    fold = parsed.fold
+                except ValueError as e:
+                    raise ValueError(f"Invalid time string: {value}") from e
+
+        # Apply precision truncation if needed
+        if cls._precision < 6 and microsecond != 0:
+            factor = 10 ** (6 - cls._precision)
+            microsecond = (microsecond // factor) * factor
+
+        try:
+            return super().__new__(
+                cls, int(hour), int(minute), int(second), int(microsecond), tzinfo=tzinfo, fold=fold
+            )
+        except (ValueError, TypeError) as e:
+            raise ValueError("Invalid time components") from e
 
     @property
     def sql_type(self) -> str:
-        if self.precision != 6:
-            return f"TIME({self.precision})"
-        return "TIME"
+        """Return SQL type for compatibility."""
+        if self._precision != 6:
+            return f"TIME({self._precision})"
+        return self.SQL_TYPE
+
+    def serialize(self) -> str:
+        """Serialize to ISO format string for SQL."""
+        return self.isoformat()
+
+    @classmethod
+    def validate(cls, value: Any) -> time:
+        """Validate a value without creating an instance (compatibility method)."""
+        instance = cls(value)
+        return time(
+            instance.hour,
+            instance.minute,
+            instance.second,
+            instance.microsecond,
+            tzinfo=instance.tzinfo,
+        )
+
+    @classmethod
+    def __get_pydantic_core_schema__(cls, source_type: Any, handler: GetCoreSchemaHandler) -> Any:
+        """Define Pydantic validation schema."""
+        if not PYDANTIC_AVAILABLE:
+            return None
+
+        def validate_time(value: Any) -> time:
+            """Validate and convert to time."""
+            try:
+                instance = cls(value)
+                return time(
+                    instance.hour,
+                    instance.minute,
+                    instance.second,
+                    instance.microsecond,
+                    tzinfo=instance.tzinfo,
+                )
+            except ValueError as e:
+                raise PydanticCustomError("time_type", str(e)) from e
+
+        return core_schema.no_info_after_validator_function(  # type: ignore
+            validate_time,
+            core_schema.union_schema(  # type: ignore
+                [
+                    core_schema.time_schema(),  # type: ignore
+                    core_schema.datetime_schema(),  # type: ignore
+                    core_schema.str_schema(),  # type: ignore
+                ]
+            ),
+        )
+
+    @classmethod
+    def mock(cls) -> time:
+        """Generate mock time value."""
+        try:
+            from faker import Faker  # type: ignore
+
+            fake = Faker()
+            return fake.time_object()
+        except ImportError:
+            raise ImportError("faker library is required for mock generation") from None
+
+
+class DATETIME(datetime):
+    """DateTime type that validates at instantiation (no timezone)."""
+
+    SQL_TYPE: ClassVar[str] = "DATETIME"
+    _precision: ClassVar[int] = 6
+
+    def __new__(  # type: ignore
+        cls,
+        year: Any,
+        month: Any = 1,
+        day: Any = 1,
+        hour: Any = 0,
+        minute: Any = 0,
+        second: Any = 0,
+        microsecond: Any = 0,
+        tzinfo: Any = None,
+        *,
+        fold: int = 0,
+    ):
+        """Create new datetime with validation.
+
+        Can be called with:
+        - DATETIME(2024, 3, 15, 14, 30, 45) - components
+        - DATETIME("2024-03-15T14:30:45") - ISO format string
+        - DATETIME(datetime_obj) - existing datetime object
+        - DATETIME(date_obj) - date (sets time to 00:00:00)
+        """
+        # Handle single argument case
+        if isinstance(year, (str, date, datetime)) and month == 1 and day == 1:
+            value = year
+
+            if value is None:  # type: ignore[comparison-overlap]
+                raise ValueError("DATETIME cannot be None")
+
+            # Handle existing datetime
+            if isinstance(value, datetime):
+                year = value.year
+                month = value.month
+                day = value.day
+                hour = value.hour
+                minute = value.minute
+                second = value.second
+                microsecond = value.microsecond
+                # DATETIME should not have timezone
+                tzinfo = None
+            # Handle date
+            elif isinstance(value, date):
+                year = value.year
+                month = value.month
+                day = value.day
+                hour = minute = second = microsecond = 0
+                tzinfo = None
+            # Handle string
+            elif isinstance(value, str):  # type: ignore[unreachable]
+                try:
+                    parsed = datetime.fromisoformat(value)
+                    year = parsed.year
+                    month = parsed.month
+                    day = parsed.day
+                    hour = parsed.hour
+                    minute = parsed.minute
+                    second = parsed.second
+                    microsecond = parsed.microsecond
+                    # DATETIME should not have timezone
+                    tzinfo = None
+                except ValueError as e:
+                    raise ValueError(f"Invalid datetime string: {value}") from e
+
+        # Apply precision truncation if needed
+        if cls._precision < 6 and microsecond != 0:
+            factor = 10 ** (6 - cls._precision)
+            microsecond = (microsecond // factor) * factor
+
+        # DATETIME should never have timezone
+        if tzinfo is not None:
+            raise ValueError(
+                "DATETIME type does not support timezone. Use TIMESTAMP for timezone support."
+            )
+
+        try:
+            return super().__new__(
+                cls,
+                int(year),
+                int(month),
+                int(day),
+                int(hour),
+                int(minute),
+                int(second),
+                int(microsecond),
+                tzinfo=None,
+                fold=fold,
+            )
+        except (ValueError, TypeError) as e:
+            raise ValueError("Invalid datetime components") from e
 
     @property
-    def python_type(self) -> type[time]:
-        return time
+    def sql_type(self) -> str:
+        """Return SQL type for compatibility."""
+        if self._precision != 6:
+            return f"DATETIME({self._precision})"
+        return self.SQL_TYPE
 
-    def _validate_custom(self, value: Any) -> None:
-        """Validate time value."""
-        if not isinstance(value, (time, datetime, str)):
-            raise ValueError(f"Expected time value, got {type(value).__name__}")
+    def serialize(self) -> str:
+        """Serialize to ISO format string for SQL."""
+        return self.isoformat()
 
-        if isinstance(value, str):
+    @classmethod
+    def validate(cls, value: Any) -> datetime:
+        """Validate a value without creating an instance (compatibility method)."""
+        instance = cls(value)
+        return datetime(  # noqa: DTZ001
+            instance.year,
+            instance.month,
+            instance.day,
+            instance.hour,
+            instance.minute,
+            instance.second,
+            instance.microsecond,
+        )
+
+    @classmethod
+    def __get_pydantic_core_schema__(cls, source_type: Any, handler: GetCoreSchemaHandler) -> Any:
+        """Define Pydantic validation schema."""
+        if not PYDANTIC_AVAILABLE:
+            return None
+
+        def validate_datetime(value: Any) -> datetime:
+            """Validate and convert to datetime."""
             try:
-                time.fromisoformat(value)
+                instance = cls(value)
+                return datetime(  # noqa: DTZ001
+                    instance.year,
+                    instance.month,
+                    instance.day,
+                    instance.hour,
+                    instance.minute,
+                    instance.second,
+                    instance.microsecond,
+                )
             except ValueError as e:
-                raise ValueError(f"Invalid time string: {e}") from e
+                raise PydanticCustomError("datetime_type", str(e)) from e
 
-    def _serialize(self, value: Union[time, datetime, str]) -> str:
-        if isinstance(value, datetime):
-            time_val = value.time()
-        elif isinstance(value, time):
-            time_val = value
-        else:  # str
-            time_val = time.fromisoformat(value)
+        return core_schema.no_info_after_validator_function(  # type: ignore
+            validate_datetime,
+            core_schema.union_schema(  # type: ignore
+                [
+                    core_schema.datetime_schema(),  # type: ignore
+                    core_schema.date_schema(),  # type: ignore
+                    core_schema.str_schema(),  # type: ignore
+                ]
+            ),
+        )
 
-        # Truncate microseconds based on precision
-        if self.precision < 6:
-            microseconds = time_val.microsecond
-            factor = 10 ** (6 - self.precision)
-            microseconds = (microseconds // factor) * factor
-            time_val = time_val.replace(microsecond=microseconds)
+    @classmethod
+    def mock(cls) -> datetime:
+        """Generate mock datetime value."""
+        try:
+            from faker import Faker  # type: ignore
 
-        return time_val.isoformat()
-
-    def _deserialize(self, value: Any) -> time:
-        if isinstance(value, time) and not isinstance(value, datetime):
-            return value
-        elif isinstance(value, datetime):
-            return value.time()
-        else:
-            return time.fromisoformat(str(value))
+            fake = Faker()
+            # Return without timezone for DATETIME
+            dt = fake.date_time()
+            return dt.replace(tzinfo=None)
+        except ImportError:
+            raise ImportError("faker library is required for mock generation") from None
 
 
-class TIMESTAMP(DBType[datetime]):
+class TIMESTAMP(datetime):
     """Timestamp type with timezone support."""
 
-    def __init__(self, precision: int = 6, with_timezone: bool = True):
-        super().__init__()
-        if precision < 0 or precision > 6:
-            raise ValueError("Timestamp precision must be between 0 and 6")
-        self.precision = precision
-        self.with_timezone = with_timezone
+    SQL_TYPE: ClassVar[str] = "TIMESTAMP"
+    _precision: ClassVar[int] = 6
+    _with_timezone: ClassVar[bool] = True
+
+    def __new__(  # type: ignore
+        cls,
+        year: Any,
+        month: Any = 1,
+        day: Any = 1,
+        hour: Any = 0,
+        minute: Any = 0,
+        second: Any = 0,
+        microsecond: Any = 0,
+        tzinfo: Any = None,
+        *,
+        fold: int = 0,
+    ):
+        """Create new timestamp with validation.
+
+        Can be called with:
+        - TIMESTAMP(2024, 3, 15, 14, 30, 45) - components
+        - TIMESTAMP("2024-03-15T14:30:45+00:00") - ISO format string
+        - TIMESTAMP(datetime_obj) - existing datetime object
+        - TIMESTAMP(date_obj) - date (sets time to 00:00:00)
+        """
+        # Handle single argument case
+        if isinstance(year, (str, date, datetime)) and month == 1 and day == 1:
+            value = year
+
+            if value is None:  # type: ignore[comparison-overlap]
+                raise ValueError("TIMESTAMP cannot be None")
+
+            # Handle existing datetime
+            if isinstance(value, datetime):
+                year = value.year
+                month = value.month
+                day = value.day
+                hour = value.hour
+                minute = value.minute
+                second = value.second
+                microsecond = value.microsecond
+                tzinfo = value.tzinfo
+            # Handle date
+            elif isinstance(value, date):
+                year = value.year
+                month = value.month
+                day = value.day
+                hour = minute = second = microsecond = 0
+                tzinfo = timezone.utc if cls._with_timezone else None
+            # Handle string
+            elif isinstance(value, str):  # type: ignore[unreachable]
+                try:
+                    # Handle 'Z' suffix for UTC
+                    if value.endswith("Z"):
+                        value = value[:-1] + "+00:00"
+                    parsed = datetime.fromisoformat(value)
+                    year = parsed.year
+                    month = parsed.month
+                    day = parsed.day
+                    hour = parsed.hour
+                    minute = parsed.minute
+                    second = parsed.second
+                    microsecond = parsed.microsecond
+                    tzinfo = parsed.tzinfo
+                except ValueError as e:
+                    raise ValueError(f"Invalid timestamp string: {value}") from e
+
+        # Apply precision truncation if needed
+        if cls._precision < 6 and microsecond != 0:
+            factor = 10 ** (6 - cls._precision)
+            microsecond = (microsecond // factor) * factor
+
+        # Check timezone requirements
+        if cls._with_timezone and tzinfo is None:
+            # Default to UTC for timestamp with timezone
+            tzinfo = timezone.utc
+        elif not cls._with_timezone and tzinfo is not None:
+            # Remove timezone for timestamp without timezone
+            tzinfo = None
+
+        try:
+            return super().__new__(
+                cls,
+                int(year),
+                int(month),
+                int(day),
+                int(hour),
+                int(minute),
+                int(second),
+                int(microsecond),
+                tzinfo=tzinfo,
+                fold=fold,
+            )
+        except (ValueError, TypeError) as e:
+            raise ValueError("Invalid timestamp components") from e
 
     @property
     def sql_type(self) -> str:
-        tz_suffix = " WITH TIME ZONE" if self.with_timezone else ""
-        if self.precision != 6:
-            return f"TIMESTAMP({self.precision}){tz_suffix}"
+        """Return SQL type for compatibility."""
+        tz_suffix = " WITH TIME ZONE" if self._with_timezone else ""
+        if self._precision != 6:
+            return f"TIMESTAMP({self._precision}){tz_suffix}"
         return f"TIMESTAMP{tz_suffix}"
 
-    @property
-    def python_type(self) -> type[datetime]:
-        return datetime
+    def serialize(self) -> str:
+        """Serialize to ISO format string for SQL."""
+        return self.isoformat()
 
-    def _validate_custom(self, value: Any) -> None:
-        """Validate timestamp value."""
-        if not isinstance(value, (datetime, date, str)):
-            raise ValueError(f"Expected datetime value, got {type(value).__name__}")
+    @classmethod
+    def validate(cls, value: Any) -> datetime:
+        """Validate a value without creating an instance (compatibility method)."""
+        instance = cls(value)
+        return datetime(
+            instance.year,
+            instance.month,
+            instance.day,
+            instance.hour,
+            instance.minute,
+            instance.second,
+            instance.microsecond,
+            tzinfo=instance.tzinfo,
+        )
 
-        if isinstance(value, str):
+    @classmethod
+    def __get_pydantic_core_schema__(cls, source_type: Any, handler: GetCoreSchemaHandler) -> Any:
+        """Define Pydantic validation schema."""
+        if not PYDANTIC_AVAILABLE:
+            return None
+
+        def validate_timestamp(value: Any) -> datetime:
+            """Validate and convert to timestamp."""
             try:
-                datetime.fromisoformat(value)
+                instance = cls(value)
+                return datetime(
+                    instance.year,
+                    instance.month,
+                    instance.day,
+                    instance.hour,
+                    instance.minute,
+                    instance.second,
+                    instance.microsecond,
+                    tzinfo=instance.tzinfo,
+                )
             except ValueError as e:
-                raise ValueError(f"Invalid datetime string: {e}") from e
+                raise PydanticCustomError("timestamp_type", str(e)) from e
 
-        if isinstance(value, datetime) and self.with_timezone and value.tzinfo is None:
-            raise ValueError("Timestamp with timezone requires timezone-aware datetime")
+        return core_schema.no_info_after_validator_function(  # type: ignore
+            validate_timestamp,
+            core_schema.union_schema(  # type: ignore
+                [
+                    core_schema.datetime_schema(),  # type: ignore
+                    core_schema.date_schema(),  # type: ignore
+                    core_schema.str_schema(),  # type: ignore
+                ]
+            ),
+        )
 
-    def _serialize(self, value: Union[datetime, date, str]) -> str:
-        if isinstance(value, date) and not isinstance(value, datetime):
-            dt_value = datetime.combine(value, time.min)
-        elif isinstance(value, datetime):
-            dt_value = value
-        else:  # str
-            dt_value = datetime.fromisoformat(value)
+    @classmethod
+    def mock(cls) -> datetime:
+        """Generate mock timestamp value."""
+        try:
+            from faker import Faker  # type: ignore
 
-        # Truncate microseconds based on precision
-        if self.precision < 6:
-            microseconds = dt_value.microsecond
-            factor = 10 ** (6 - self.precision)
-            microseconds = (microseconds // factor) * factor
-            dt_value = dt_value.replace(microsecond=microseconds)
-
-        return dt_value.isoformat()
-
-    def _deserialize(self, value: Any) -> datetime:
-        if isinstance(value, datetime):
-            return value
-        elif isinstance(value, date):
-            return datetime.combine(value, time.min)
-        else:
-            return datetime.fromisoformat(str(value))
-
-    def __repr__(self) -> str:
-        parts = [f"precision={self.precision}"]
-        if self.with_timezone:
-            parts.append("with_timezone=True")
-        return f"TIMESTAMP({', '.join(parts)})"
+            fake = Faker()
+            dt = fake.date_time()
+            if cls._with_timezone:
+                # Add UTC timezone
+                return dt.replace(tzinfo=timezone.utc)
+            else:
+                return dt.replace(tzinfo=None)
+        except ImportError:
+            raise ImportError("faker library is required for mock generation") from None
 
 
-class DATETIME(TIMESTAMP):
-    """Alias for TIMESTAMP without timezone."""
+# Factory functions
+def Date() -> type:  # noqa: N802
+    """Create a Date type for use as type annotation.
 
-    def __init__(self, precision: int = 6):
-        super().__init__(precision, with_timezone=False)
+    Example:
+        class Person(BaseModel):
+            birth_date: Date()
+            hire_date: Date()
+    """
+    return DATE
 
-    @property
-    def sql_type(self) -> str:
-        if self.precision != 6:
-            return f"DATETIME({self.precision})"
-        return "DATETIME"
+
+def Time(precision: int = 6) -> type:  # noqa: N802
+    """Create a Time type with optional precision.
+
+    Args:
+        precision: Number of fractional seconds digits (0-6)
+
+    Example:
+        class Schedule(BaseModel):
+            start_time: Time()
+            end_time: Time(precision=0)  # No fractional seconds
+    """
+    if precision < 0 or precision > 6:
+        raise ValueError("Time precision must be between 0 and 6")
+
+    class ConstrainedTime(TIME):
+        _precision = precision
+        SQL_TYPE = "TIME"
+
+    return ConstrainedTime
+
+
+def DateTime(precision: int = 6) -> type:  # noqa: N802
+    """Create a DateTime type with optional precision.
+
+    Args:
+        precision: Number of fractional seconds digits (0-6)
+
+    Example:
+        class Log(BaseModel):
+            timestamp: DateTime()
+            processed: DateTime(precision=0)
+    """
+    if precision < 0 or precision > 6:
+        raise ValueError("DateTime precision must be between 0 and 6")
+
+    class ConstrainedDateTime(DATETIME):
+        _precision = precision
+        SQL_TYPE = "DATETIME"
+
+    return ConstrainedDateTime
+
+
+def Timestamp(precision: int = 6, with_timezone: bool = True) -> type:  # noqa: N802
+    """Create a Timestamp type with optional timezone.
+
+    Args:
+        precision: Number of fractional seconds digits (0-6)
+        with_timezone: Whether to include timezone information
+
+    Example:
+        class Event(BaseModel):
+            created_at: Timestamp()
+            updated_at: Timestamp(with_timezone=False)
+            processed_at: Timestamp(precision=3)  # Milliseconds
+    """
+    if precision < 0 or precision > 6:
+        raise ValueError("Timestamp precision must be between 0 and 6")
+
+    class ConstrainedTimestamp(TIMESTAMP):
+        _precision = precision
+        _with_timezone = with_timezone
+        SQL_TYPE = "TIMESTAMP"
+
+    return ConstrainedTimestamp

--- a/tests/test_mock_factory.py
+++ b/tests/test_mock_factory.py
@@ -424,15 +424,18 @@ class TestDefaultMockImplementation:
         """Test that temporal types use default mock implementation."""
         from datetime import time
 
-        from mocksmith import DATE, TIME, TIMESTAMP
+        from mocksmith import Date, Time, Timestamp
 
-        date_mock = DATE().mock()
+        DateType = Date()  # noqa: N806
+        date_mock = DateType.mock()
         assert isinstance(date_mock, date)
 
-        time_mock = TIME().mock()
+        TimeType = Time()  # noqa: N806
+        time_mock = TimeType.mock()
         assert isinstance(time_mock, time)
 
-        timestamp_mock = TIMESTAMP().mock()
+        TimestampType = Timestamp()  # noqa: N806
+        timestamp_mock = TimestampType.mock()
         assert isinstance(timestamp_mock, datetime)
 
     def test_binary_types_default_mock(self):

--- a/tests/test_pydantic_integration.py
+++ b/tests/test_pydantic_integration.py
@@ -83,10 +83,10 @@ class TestPydanticIntegration:
 
         user = User(name="Alice", joined=date(2023, 1, 1), active=True)
 
-        # Pydantic serialization - our DBTypeValidator serializes dates to strings
+        # Pydantic serialization - V3 types return native Python types
         data = user.model_dump()
         assert data["name"] == "Alice"
-        assert data["joined"] == "2023-01-01"  # DBTypeValidator serializes to ISO string
+        assert data["joined"] == date(2023, 1, 1)  # V3 types return native date objects
         assert data["active"] is True
 
     def test_db_model_base(self):


### PR DESCRIPTION
  BREAKING CHANGE: Temporal types now extend native Python datetime types directly

  - Migrated DATE type to extend Python date
  - Migrated TIME type to extend Python time
  - Migrated DATETIME and TIMESTAMP types to extend Python datetime
  - Removed old DBType-based temporal implementations
  - Added instantiation-time validation for all temporal types
  - Updated factory functions (Date, Time, DateTime, Timestamp) to return type classes
  - Added precision support for TIME, DATETIME, and TIMESTAMP
  - Added timezone support control for TIMESTAMP
  - Fixed handling of 'Z' timezone suffix in ISO format strings
  - Updated all tests to work with V3 pattern
  - Fixed type annotations in annotations.py
  - Native Python datetime types are returned from Pydantic models

  The new types validate at instantiation and work seamlessly with both
  Pydantic models and regular Python code. Mock generation is fully supported.